### PR TITLE
Fix 2 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 This repository holds code examples supporting blog posts on [Spring Framework Guru](http://springframework.guru)
 
 * [Monetary Calculation Pitfalls in Java](https://springframework.guru/monetary-calculation-pitfalls/) 
-* [Open Closed Principle in Java](https://springframework.guru/open-closed-principle/‎)
-* [Dependency Inversion Principle](https://springframework.guru/dependency-inversion-principle/‎)
+* [Open Closed Principle in Java](https://springframework.guru/open-closed-principle/)
+* [Dependency Inversion Principle](https://springframework.guru/dependency-inversion-principle/)
 * [Interface Segregation Principle](https://springframework.guru/interface-segregation-principle/)
 * [Running code via Spring Events in Spring Boot](https://springframework.guru/running-code-on-spring-boot-startup/)
 * [Sorting Java ArrayList](https://springframework.guru/sorting-java-arraylist/)


### PR DESCRIPTION
Remove the invisible character at the end end of URLS that cause navigation error (https://springframework.guru/dependency-inversion-principle/%E2%80%8E) in : 
- Open Closed Principle in Java
- Dependency Inversion Principle

![image](https://user-images.githubusercontent.com/27820864/70984690-3649c980-20bb-11ea-98ba-ac9f10da0204.png)
